### PR TITLE
 Fix Makefile and README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,14 @@ LAMBDA_DEPLOY_BUCKET ?= deploy-bucket
 .PHONY: lambda
 lambda: ## Build lambda package
 	mkdir -p dist/lambda
-	go build -o dist/lambda/main ./lambda
+	GOOS=linux GOARCH=amd64 go build -o dist/lambda/main ./lambda
 	cd dist/lambda && zip -r $(LAMBDA_FILENAME) main
 
 deploy_lambda: ## Deploy lambda artifact
 	aws s3api put-object --bucket $(LAMBDA_DEPLOY_BUCKET) --key $(LAMBDA_PATH)/$(LAMBDA_FILENAME) --body dist/lambda/$(LAMBDA_FILENAME)
 
 binary: ## Build fetch binary
-	go build -o dist/fetch ./fetch
+	go build -o dist/fetch cmd/main.go
 
 docker: ## Build docker image
 	docker build -t $(DOCKER_IMAGE_NAME) .

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ go get github.com/OpenBazaar/tickerproxy
 ## Run
 
 ```go
-go run "$GOPATH/src/github.com/OpenBazaar/tickerproxy/bin/main.go"
+go run "$GOPATH/src/github.com/OpenBazaar/tickerproxy/cmd/main.go"
 ```
 
 ## Configuration and defaults


### PR DESCRIPTION
- Specify `GOOS` and `GOARCH` environments for Lambda
- Edit path to `main.go` on README to the correct one